### PR TITLE
Middleware is always giving a string to the Shield::verify method

### DIFF
--- a/src/ShieldMiddleware.php
+++ b/src/ShieldMiddleware.php
@@ -52,7 +52,7 @@ class ShieldMiddleware
      */
     public function handle($request, Closure $next, string $user = null)
     {
-        $this->shield->verify($request->getUser(), $request->getPassword(), $user);
+        $this->shield->verify($request->getUser() ?: '', $request->getPassword() ?: '', $user);
 
         return $next($request);
     }


### PR DESCRIPTION
The Shield::verify method expects two strings, but $request->getUser and $request->getPassword are returning null if there is no user in the HTTP header of the request. So the verify method fails before it can throw the UnauthorizedHttpException('Basic'). But this is needed to get the login screen of the browser and send the appropriate HTTP Header with username and password.